### PR TITLE
chore: run circleci for node 4 too

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,11 +22,13 @@ workflows:
   version: 2
   tests:
     jobs:
+      - node4
       - node6
       - node8
       - node9
       - publish_npm:
           requires:
+            - node4
             - node6
             - node8
             - node9
@@ -37,6 +39,10 @@ workflows:
               only: /^v[\d.]+$/
 
 jobs:
+  node4:
+    docker:
+      - image: node:4
+    <<: *unit_tests
   node6:
     docker:
       - image: node:6


### PR DESCRIPTION
It turns out that `jsgl` runs with Node 4 as well as 6+. Run tests for
Node 4 too.