### PR TITLE
chore: export `GitHubRepository` from checker.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@ This is a tool for checking the license of JavaScript projects. It scans the
 `package.json` file to check its license and recursively checks all of its
 dependencies.
 
+## Installation
+
+```shell
+npm install [--save-dev] js-green-licenses
+```
+
+If you want to install globally,
+
+```shell
+npm install -g js-green-licenses
+```
+
 ## CLI
 
 ```

--- a/ts/src/checker.ts
+++ b/ts/src/checker.ts
@@ -27,6 +27,8 @@ import packageJson = require('package-json');
 import spdxCorrect = require('spdx-correct');
 import spdxSatisfies = require('spdx-satisfies');
 
+export {GitHubRepository} from './github';
+
 const fsAccess = pify(fs.access);
 const fsReadDir = pify(fs.readdir);
 const fsReadFile = pify(fs.readFile);


### PR DESCRIPTION
It should've been exported from the beginning. Otherwise client code
can't use the github-related APIs when using this package as a library.