### PR TITLE
Refactor CLI logic for easier use from Gulp.

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,21 @@ When `dev` is true, the `devDependencies` section is checked as well as the
 `dependencies` section of `package.json`. When `verbose` is true, `jsgl`
 generates more verbose output.
 
+### Use in Gulp
+
+```javascript
+const jsgl = require('js-green-licenses');
+
+gulp.task('check_licenses', function() {
+  const checker = new jsgl.LicenseChecker({
+    dev: true,
+    verbose: false,
+  });
+  checker.setDefaultHandlers();
+  return checker.checkLocalDirectory('.');
+});
+```
+
 ### Methods
 
 *   `LicenseChecker#checkLocalDirectory()`

--- a/ts/src/cli.ts
+++ b/ts/src/cli.ts
@@ -15,7 +15,6 @@
 // limitations under the License.
 
 import {ArgumentParser} from 'argparse';
-import {inspect} from 'util';
 
 import {LicenseChecker, NonGreenLicense} from './checker';
 
@@ -58,48 +57,7 @@ const args = argParser.parseArgs();
 async function main(): Promise<void> {
   const checker =
       new LicenseChecker({dev: !!args.dev, verbose: !!args.verbose});
-  let nonGreenCount = 0;
-  let errorCount = 0;
-  checker
-      .on('non-green-license',
-          ({packageName, version, licenseName, parentPackages}) => {
-            nonGreenCount++;
-            const licenseDisplay = licenseName || '(no license)';
-            const packageAndVersion = `${packageName}@${version}`;
-            console.log(`${licenseDisplay}: ${packageAndVersion}`);
-            console.log(
-                `  ${[...parentPackages, packageAndVersion].join(' -> ')}`);
-            console.log();
-          })
-      .on('package.json',
-          (filePath) => {
-            console.log(`Checking ${filePath}...`);
-            console.log();
-          })
-      .on('error',
-          ({err, packageName, versionSpec, parentPackages}) => {
-            errorCount++;
-            const packageAndVersion = `${packageName}@${versionSpec}`;
-            console.log(`Error while checking ${packageAndVersion}:`);
-            console.log(
-                `  ${[...parentPackages, packageAndVersion].join(' -> ')}`);
-            console.log();
-            console.log(`${inspect(err)}`);
-            console.log();
-          })
-      .on('end', () => {
-        if (nonGreenCount > 0 || errorCount > 0) {
-          process.exitCode = 1;
-          if (nonGreenCount > 0) {
-            console.log(`${nonGreenCount} non-green licenses found.`);
-          }
-          if (errorCount > 0) {
-            console.log(`${errorCount} errors found.`);
-          }
-        } else {
-          console.log('All green!');
-        }
-      });
+  checker.setDefaultHandlers();
   if (args.local) {
     await checker.checkLocalDirectory(args.local[0]);
   } else if (args.pr) {

--- a/ts/test/checker-test.ts
+++ b/ts/test/checker-test.ts
@@ -246,3 +246,24 @@ test.serial('custom green license list (local repo)', async t => {
     mockFs.restore();
   }
 });
+
+test.serial('errors properly output to console', async t => {
+  // temporarily mock out global console.log so we can see what gets
+  // written there.
+  const realConsoleLog = console.log;
+  let consoleOutput = '';
+  console.log = (output) => {
+    if (output !== undefined) {
+      consoleOutput += output;
+    }
+    consoleOutput += '\n';
+  };
+  requestedPackages = [];
+  const nonGreenPackages: string[] = [];
+  const checker = new LicenseChecker({});
+  checker.setDefaultHandlers();
+  await checker.checkRemotePackage('foo');
+  console.log = realConsoleLog;
+  t.regex(consoleOutput, /EVIL: bar@4\.5\.6/);
+  t.regex(consoleOutput, /1 non-green licenses found\./);
+});


### PR DESCRIPTION
Factor out the default handlers for CLI output so they can be reused as part
of the library (i.e. for Gulp or similar systems.)