### PR TITLE
feat: allow comments in config json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,17 +130,19 @@ You can whitelist that package to make `jsgl` not complain about that
 package.
 
 A typical configuration file looks like this:
-```json
+```javascript
 {
   "greenLicenses": [
+    // Custom green licenses.
     "Apache-2.0",
     "MIT",
     "BSD-3-Clause",
     ...
   ],
   "packageWhitelist": [
+    /* packages considered ok */
     "foo",
-    "bar",
+    "bar",  // inline comment
     "package-with-no-license",
     "package-with-okish-license",
     ...
@@ -150,6 +152,8 @@ A typical configuration file looks like this:
 
 The `greenLicenses` section is for the custom license list and the
 `packageWhitelist` section is for the package whitelist.
+
+Note that comments are allowed in `js-green-licenses.json`.
 
 The configuration file must be located in the top-level directory of a
 repository for `--local` and `--pr`. When checking remote NPM packages,

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,22 +92,22 @@
       "integrity": "sha1-TYElQeh7I1dyYaWqlfcE3T0B5BA=",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.1"
+        "@types/node": "8.5.7"
       }
     },
     "@types/nock": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@types/nock/-/nock-9.1.0.tgz",
-      "integrity": "sha512-Ykk50z1MKpHDRmnBJb6kn3rU03cCsbjHmqCzY3eyeDNxdz3mrgbbwwXRXzBnPXkD9qzGh1ZU9XLdbQVp6i0+gQ==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@types/nock/-/nock-9.1.1.tgz",
+      "integrity": "sha512-vXKQQKjixGtZclT6HgHTXvspiLyNQvzswry80oIRSLkM83GsS9o87w/bJmGmC6Hrs8dOi+5lfdyDPTIDCmLSpA==",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.1"
+        "@types/node": "8.5.7"
       }
     },
     "@types/node": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.1.tgz",
-      "integrity": "sha512-SrmAO+NhnsuG/6TychSl2VdxBZiw/d6V+8j+DFo8O3PwFi+QeYXWHhAw+b170aSc6zYab6/PjEWRZHIDN9mNUw==",
+      "version": "8.5.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.7.tgz",
+      "integrity": "sha512-+1ZfzGIq8Y3EV7hPF7bs3i+Gi2mqYOiEGGRxGYPrn+hTYLMmzg+/5TkMkCHiRtLB38XSNvr/43aQ9+cUq4BbBg==",
       "dev": true
     },
     "@types/npm-package-arg": {
@@ -144,6 +144,12 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@types/spdx-satisfies/-/spdx-satisfies-0.1.0.tgz",
       "integrity": "sha512-Y3Faje1Gi/l+tSjAo52Lpm3fLnpQtQLfYcmpInikSoHBxckOFKl1uGWVfRyI3LnX2+brcRUDox7T08eJ60UQlQ==",
+      "dev": true
+    },
+    "@types/strip-json-comments": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
+      "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
       "dev": true
     },
     "ajv": {
@@ -2937,9 +2943,9 @@
       "dev": true
     },
     "gts": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/gts/-/gts-0.5.2.tgz",
-      "integrity": "sha512-XnsRWIBBAwXx+ta/ra0foqQ7D1nUqZ0GbL2I5vJK96wK14X16xl3uaMGb1D+DZDWfaQAH7h+R1F7KEuUfvDsNQ==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/gts/-/gts-0.5.3.tgz",
+      "integrity": "sha512-MiC5I1cAYjuGq68Xc9esn1qQcfl/on154+Oux8y6xWv03Ql9DGGsAokFVzgqNFDV65wd38uXYcPNaeeIl/EOjg==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
@@ -3994,9 +4000,9 @@
       "optional": true
     },
     "nock": {
-      "version": "9.1.4",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-9.1.4.tgz",
-      "integrity": "sha512-O0tkPO0VkiQ7mfCAg3QyL+6tt7srXHq0+m6BMy+SyzuKX+2Oz10ERXnqDL0nJxpVhKFx/E/K/6nT75U6RpvugQ==",
+      "version": "9.1.5",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-9.1.5.tgz",
+      "integrity": "sha512-ukkBUhGU73CmSKTpTl6N/Qjvb7Hev4rCEjgOuEBKvHmsOqz7jGh2vUXL3dPnX3ndfcmVjsFBPfKpNuJbK94SKg==",
       "dev": true,
       "requires": {
         "chai": "3.5.0",
@@ -6840,13 +6846,13 @@
         "resolve": "1.5.0",
         "semver": "5.4.1",
         "tslib": "1.8.1",
-        "tsutils": "2.13.0"
+        "tsutils": "2.15.0"
       }
     },
     "tsutils": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.13.0.tgz",
-      "integrity": "sha512-FuWzNJbMsp3gcZMbI3b5DomhW4Ia41vMxjN63nKWI0t7f+I3UmHfRl0TrXJTwI2LUduDG+eR1Mksp3pvtlyCFQ==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.15.0.tgz",
+      "integrity": "sha512-kKb1mSqRMwF0GHKya5/hZsI2m7Flg4ONZDeYu4e6Gx+kYAu86zsLNCHcUmNWhCRaUcKshNI272hOzuaCQDzJ2g==",
       "dev": true,
       "requires": {
         "tslib": "1.8.1"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,11 @@
       "build/test/*-test.js"
     ]
   },
+  "nyc": {
+    "exclude": [
+      "build/test"
+    ]
+  },
   "dependencies": {
     "argparse": "^1.0.9",
     "axios": "^0.17.1",
@@ -40,24 +45,26 @@
     "package-json": "^4.0.1",
     "pify": "^3.0.0",
     "spdx-correct": "^2.0.4",
-    "spdx-satisfies": "^0.1.3"
+    "spdx-satisfies": "^0.1.3",
+    "strip-json-comments": "^2.0.1"
   },
   "devDependencies": {
     "@types/argparse": "^1.0.33",
     "@types/mock-fs": "^3.6.30",
-    "@types/nock": "^9.1.0",
-    "@types/node": "^8.5.1",
+    "@types/nock": "^9.1.1",
+    "@types/node": "^8.5.7",
     "@types/npm-package-arg": "^5.1.0",
     "@types/package-json": "^4.0.1",
     "@types/pify": "^3.0.0",
     "@types/proxyquire": "^1.3.28",
     "@types/spdx-correct": "^2.0.0",
     "@types/spdx-satisfies": "^0.1.0",
+    "@types/strip-json-comments": "0.0.30",
     "ava": "^0.24.0",
     "codecov": "^3.0.0",
-    "gts": "^0.5.2",
+    "gts": "^0.5.3",
     "mock-fs": "^4.4.2",
-    "nock": "^9.1.4",
+    "nock": "^9.1.5",
     "nyc": "^11.4.1",
     "proxyquire": "^1.8.0",
     "typescript": "~2.6.2"

--- a/ts/src/config.ts
+++ b/ts/src/config.ts
@@ -1,3 +1,17 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import * as fs from 'fs';
 import * as path from 'path';
 import * as pify from 'pify';

--- a/ts/src/config.ts
+++ b/ts/src/config.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as pify from 'pify';
+import * as stripJsonComments from 'strip-json-comments';
 
 import {GitHubRepository} from './github';
 
@@ -32,11 +33,15 @@ function ensureConfig(obj: {}): Config {
   return obj;
 }
 
+function parseJson(input: string): {} {
+  return JSON.parse(stripJsonComments(input));
+}
+
 export async function getLocalConfig(directory: string): Promise<Config|null> {
   try {
     const content =
         await fsReadFile(path.join(directory, CONFIG_FILE_NAME), 'utf8');
-    return ensureConfig(JSON.parse(content));
+    return ensureConfig(parseJson(content));
   } catch (err) {
     if (err.code !== 'ENOENT') {
       console.error(
@@ -53,7 +58,7 @@ export async function getGitHubConfig(
     return null;
   }
   try {
-    return ensureConfig(JSON.parse(content));
+    return ensureConfig(parseJson(content));
   } catch {
     return null;
   }

--- a/ts/src/config.ts
+++ b/ts/src/config.ts
@@ -59,7 +59,8 @@ export async function getGitHubConfig(
   }
   try {
     return ensureConfig(parseJson(content));
-  } catch {
+  } catch (err) {
+    console.error('[js-green-licenses] Error while reading config file:', err);
     return null;
   }
 }

--- a/ts/test/config-test.ts
+++ b/ts/test/config-test.ts
@@ -1,0 +1,126 @@
+import test from 'ava';
+import * as mockFs from 'mock-fs';
+
+import * as config from '../src/config';
+import {GitHubRepository} from '../src/github';
+
+test.serial('read correct contents from local config file', async (t) => {
+  const configContent = JSON.stringify({
+    greenLicenses: [
+      'FOO',
+      'BAR',
+    ],
+    packageWhitelist: [
+      'a-package',
+      'another-package',
+    ],
+  });
+  mockFs({
+    'repo/directory': {
+      'js-green-licenses.json': configContent,
+    },
+  });
+  try {
+    const cfg = await config.getLocalConfig('repo/directory');
+    t.truthy(cfg);
+    t.deepEqual(cfg!.greenLicenses, ['FOO', 'BAR']);
+    t.deepEqual(cfg!.packageWhitelist, ['a-package', 'another-package']);
+  } finally {
+    mockFs.restore();
+  }
+});
+
+test.serial('read config file from github repo', async (t) => {
+  class FakeGitHubRepository extends GitHubRepository {
+    constructor() {
+      super('janedoe', 'repo');
+    }
+
+    async getFileContent(commitSha: string, path: string):
+        Promise<string|null> {
+      return JSON.stringify({
+        greenLicenses: [
+          'BAR',
+          'BAZ',
+        ],
+        packageWhitelist: [
+          'package-1',
+          'package-2',
+        ],
+      });
+    }
+  }
+  const cfg = await config.getGitHubConfig(new FakeGitHubRepository(), '1234');
+  t.truthy(cfg);
+  t.deepEqual(cfg!.greenLicenses, ['BAR', 'BAZ']);
+  t.deepEqual(cfg!.packageWhitelist, ['package-1', 'package-2']);
+});
+
+test.serial('no config file is ok', async (t) => {
+  mockFs({
+    'repo/directory': {},
+  });
+  try {
+    const cfg = await config.getLocalConfig('repo/directory');
+    t.is(cfg, null);
+  } finally {
+    mockFs.restore();
+  }
+});
+
+test.serial('error for invalid config file', async (t) => {
+  const configContent = JSON.stringify({
+    // must be an array of strings.
+    packageWhitelist: [
+      42,
+      43,
+    ],
+  });
+  mockFs({
+    'repo/directory': {
+      'js-green-licenses.json': configContent,
+    },
+  });
+  const consoleError = console.error;
+  try {
+    let errorContents = '';
+    console.error = (message, ...params) => {
+      errorContents = `${message} ${params.join(' ')}`;
+      consoleError(message, ...params);
+    };
+    const cfg = await config.getLocalConfig('repo/directory');
+    t.is(cfg, null);
+    t.true(errorContents.indexOf('Invalid config contents') >= 0);
+  } finally {
+    console.error = consoleError;
+    mockFs.restore();
+  }
+});
+
+test.serial('comments are allowed in config file', async (t) => {
+  const configContent = `{
+    // comments are fine
+    "greenLicenses": [
+      "FOO",
+      "BAR"
+    ],
+    /* another form of comment */
+    "packageWhitelist": [
+      "foo",  // inline comment
+      "bar"
+    ]
+  }`;
+  mockFs({
+    'repo/directory': {
+      'js-green-licenses.json': configContent,
+    },
+  });
+  try {
+    const cfg = await config.getLocalConfig('repo/directory');
+    t.truthy(cfg);
+    t.deepEqual(cfg!.greenLicenses, ['FOO', 'BAR']);
+    t.deepEqual(cfg!.packageWhitelist, ['foo', 'bar']);
+  } finally {
+    mockFs.restore();
+  }
+});

--- a/ts/test/config-test.ts
+++ b/ts/test/config-test.ts
@@ -1,3 +1,17 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import test from 'ava';
 import * as mockFs from 'mock-fs';
 


### PR DESCRIPTION
Sometimes we may want to add comments in the config file. E.g. in a
package whitelist, comment on why a certain package should be
whitelisted, or comment on related github issues, etc.

Also more changes:
- Add unit tests for config.ts
- Exclude test files from coverage stats
- Update dependencies' versions