### PR TITLE
feat: emit 'package.json' event also for local repos

### DIFF
--- a/ts/src/checker.ts
+++ b/ts/src/checker.ts
@@ -93,7 +93,7 @@ export class LicenseChecker extends EventEmitter {
 
   on(event: 'non-green-license',
      listener: (arg: NonGreenLicense) => void): this;
-  // 'package.json' events are emitted only for github PR checkings.
+  // 'package.json' events are not emitted for remote packages.
   on(event: 'package.json', listener: (filePath: string) => void): this;
   on(event: 'end', listener: () => void): this;
   on(event: 'error', listener: (checkError: CheckError) => void): this;
@@ -304,6 +304,7 @@ export class LicenseChecker extends EventEmitter {
       console.log('No package.json files have been found.');
     }
     for (const pj of packageJsons) {
+      this.emit('package.json', pj);
       const content = await fsReadFile(pj, 'utf8');
       await this.checkPackageJsonContent(content);
     }

--- a/ts/test/checker-test.ts
+++ b/ts/test/checker-test.ts
@@ -164,13 +164,23 @@ test.serial('local monorepo directory is checked correctly', async t => {
   try {
     requestedPackages = [];
     const nonGreenPackages: string[] = [];
+    const packageJsonPaths: string[] = [];
     const checker = new LicenseChecker({});
-    checker.on('non-green-license', arg => {
-      nonGreenPackages.push(`${arg.packageName}@${arg.version}`);
-    });
+    checker
+        .on('non-green-license',
+            (arg) => {
+              nonGreenPackages.push(`${arg.packageName}@${arg.version}`);
+            })
+        .on('package.json', (filePath) => {
+          packageJsonPaths.push(filePath);
+        });
     await checker.checkLocalDirectory('path/to/dir');
     t.deepEqual(requestedPackages, ['foo@^1.2.3', 'bar@^4.5.0', 'baz@^7.0.0']);
     t.deepEqual(nonGreenPackages, ['bar@4.5.6', 'baz@7.8.9']);
+    t.deepEqual(packageJsonPaths, [
+      'path/to/dir/package.json',
+      'path/to/dir/packages/sub-package/package.json',
+    ]);
   } finally {
     mockFs.restore();
   }


### PR DESCRIPTION
It used to be emitted only for GitHub repos but it'll be more sane to
make it symmetric between local and github repos.