### PR TITLE
chore: let CI run for version tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,19 +22,19 @@ workflows:
   version: 2
   tests:
     jobs:
-      - node4
+      - node4:
           filters:
             tags:
               only: /^v[\d.]+$/
-      - node6
+      - node6:
           filters:
             tags:
               only: /^v[\d.]+$/
-      - node8
+      - node8:
           filters:
             tags:
               only: /^v[\d.]+$/
-      - node9
+      - node9:
           filters:
             tags:
               only: /^v[\d.]+$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,9 +23,21 @@ workflows:
   tests:
     jobs:
       - node4
+          filters:
+            tags:
+              only: /^v[\d.]+$/
       - node6
+          filters:
+            tags:
+              only: /^v[\d.]+$/
       - node8
+          filters:
+            tags:
+              only: /^v[\d.]+$/
       - node9
+          filters:
+            tags:
+              only: /^v[\d.]+$/
       - publish_npm:
           requires:
             - node4


### PR DESCRIPTION
By default, CircleCI doesn't run for tag pushes, which prevents NPM
publish from being triggered.

Let the tests run for version tag pushes so they trigger NPM publish.