### PR TITLE
chore: publish v0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-green-licenses",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "JavaScript package.json license checker",
   "main": "build/src/checker.js",
   "bin": {


### PR DESCRIPTION
The draft release note is in the GitHub UI.

I'm making this a semver minor change because there's an additional
event emitted from
https://github.com/google/js-green-licenses/pull/16. Please let me know
if you disagree.