### PR TITLE
chore: make CI run as non-root

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,6 @@ unit_tests: &unit_tests
   steps:
     - checkout
     - run:
-        name: Configure npm to allow running scripts as root.
-        command: npm config set unsafe-perm true
-    - run:
         name: Install modules and dependencies.
         command: npm install
     - run:
@@ -54,23 +51,28 @@ jobs:
   node4:
     docker:
       - image: node:4
+        user: node
     <<: *unit_tests
   node6:
     docker:
       - image: node:6
+        user: node
     <<: *unit_tests
   node8:
     docker:
       - image: node:8
+        user: node
     <<: *unit_tests
   node9:
     docker:
       - image: node:9
+        user: node
     <<: *unit_tests
 
   publish_npm:
     docker:
       - image: node:8
+        user: node
     steps:
       - checkout
       - run:

--- a/package.json
+++ b/package.json
@@ -6,6 +6,12 @@
   "bin": {
     "jsgl": "build/src/cli.js"
   },
+  "files": [
+    "CONTRIBUTING.md",
+    "LICENSE",
+    "README.md",
+    "build/src"
+  ],
   "types": "build/src/checker",
   "scripts": {
     "test": "nyc ava",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-green-licenses",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "JavaScript package.json license checker",
   "main": "build/src/checker.js",
   "bin": {


### PR DESCRIPTION
Hopefully this will fix the auto-NPM-publishing. Currently the `prepare`
phase fails.