### PR TITLE
fix: `npm publish` must be done after `npm install`.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,5 +79,8 @@ jobs:
           name: Set NPM authentication.
           command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
       - run:
-         name: Publish the module to npm.
-         command: npm publish
+          name: Install modules and dependencies.
+          command: npm install
+      - run:
+          name: Publish the module to npm.
+          command: npm publish


### PR DESCRIPTION
This fixes npm-auto-publishing.