### PR TITLE
chore: release v0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-green-licenses",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "JavaScript package.json license checker",
   "main": "build/src/checker.js",
   "bin": {


### PR DESCRIPTION
Release with many more default green licenses.

The draft release note is in the GitHub UI.