### PR TITLE
chore: define regexp only once in circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,8 @@
 ---
+release_tags: &release_tags
+  tags:
+    only: /^v\d+(\.\d+){2}(-.*)?$/
+
 # "Include" for unit tests definition.
 unit_tests: &unit_tests
   steps:
@@ -20,21 +24,13 @@ workflows:
   tests:
     jobs:
       - node4:
-          filters:
-            tags:
-              only: /^v\d+(\.\d+){2}(-.*)?$/
+          filters: *release_tags
       - node6:
-          filters:
-            tags:
-              only: /^v\d+(\.\d+){2}(-.*)?$/
+          filters: *release_tags
       - node8:
-          filters:
-            tags:
-              only: /^v\d+(\.\d+){2}(-.*)?$/
+          filters: *release_tags
       - node9:
-          filters:
-            tags:
-              only: /^v\d+(\.\d+){2}(-.*)?$/
+          filters: *release_tags
       - publish_npm:
           requires:
             - node4
@@ -44,8 +40,7 @@ workflows:
           filters:
             branches:
               ignore: /.*/
-            tags:
-              only: /^v\d+(\.\d+){2}(-.*)?$/
+            <<: *release_tags
 
 jobs:
   node4:


### PR DESCRIPTION
For the release tag regexp.