### PR TITLE
fix: retry failed packageJson()

### DIFF
--- a/ts/src/checker.ts
+++ b/ts/src/checker.ts
@@ -183,18 +183,17 @@ export class LicenseChecker extends EventEmitter {
 
   private async packageJsonWithRetry(
       packageName: string, options: {version: string, fullMetadata: boolean}) {
+    let lastError = new Error();
     for (const timeoutSec of [5, 30, 60, 0]) {
       try {
         const json = await packageJson(packageName, options);
         return json;
       } catch (err) {
-        if (timeoutSec === 0) {
-          throw err;
-        }
+        lastError = err;
         await this.sleep(timeoutSec);
       }
     }
-    throw new Error();
+    throw lastError;
   }
 
   private async checkLicenses(


### PR DESCRIPTION
In nightly builds a call to `packageJson()` can fail if NPM registry returns error, like in the screenshot below. I suggest that we just retry the call several times to reduce this kind of flakiness.

![image](https://user-images.githubusercontent.com/4015807/45538938-43438300-b7bd-11e8-9635-843514aff3ae.png)
