### PR TITLE
build!: drop support for Node 6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,6 @@ workflows:
   version: 2
   tests:
     jobs:
-      - node6:
-          filters: *release_tags
       - node8:
           filters: *release_tags
       - node10:
@@ -33,7 +31,6 @@ workflows:
           filters: *release_tags
       - publish_npm:
           requires:
-            - node6
             - node8
             - node10
             - node11
@@ -43,11 +40,6 @@ workflows:
             <<: *release_tags
 
 jobs:
-  node6:
-    docker:
-      - image: node:6
-        user: node
-    <<: *unit_tests
   node8:
     docker:
       - image: node:8

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "posttest": "npm run check && npm run check-self",
     "check-self": "node build/src/cli.js --local ."
   },
+  "engines": {
+    "node": ">= 8.x"
+  },
   "keywords": [
     "npm",
     "package",


### PR DESCRIPTION
BREAKING CHANGE: Drop support for Node.js 6.x which reaching EOL in a
couple of weeks.