### PR TITLE
refactor: prefer promisify to pify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -466,12 +466,6 @@
       "integrity": "sha512-WqgImkz7tkh6c9PUCchGrAkFpyWsrLMuxwoe267IBVs5hxnyG6piWQ69KrV+cESDPz5np2d06ocqBkQYO41jKQ==",
       "dev": true
     },
-    "@types/pify": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/pify/-/pify-3.0.2.tgz",
-      "integrity": "sha512-a5AKF1/9pCU3HGMkesgY6LsBdXHUY3WU+I2qgpU0J+I8XuJA1aFr59eS84/HP0+dxsyBSNbt+4yGI2adUpHwSg==",
-      "dev": true
-    },
     "@types/proxyquire": {
       "version": "1.3.28",
       "resolved": "https://registry.npmjs.org/@types/proxyquire/-/proxyquire-1.3.28.tgz",
@@ -5125,7 +5119,8 @@
     "pify": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true
     },
     "pinkie": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "axios": "^0.18.0",
     "npm-package-arg": "^6.1.0",
     "package-json": "^6.0.0",
-    "pify": "^4.0.0",
     "spdx-correct": "^3.0.0",
     "spdx-satisfies": "^5.0.0",
     "strip-json-comments": "^2.0.1"
@@ -63,7 +62,6 @@
     "@types/node": "^10.0.1",
     "@types/npm-package-arg": "^6.0.0",
     "@types/package-json": "^5.0.0",
-    "@types/pify": "^3.0.1",
     "@types/proxyquire": "^1.3.28",
     "@types/spdx-correct": "^2.0.0",
     "@types/spdx-satisfies": "^0.1.0",

--- a/src/checker.ts
+++ b/src/checker.ts
@@ -17,10 +17,9 @@ import * as fs from 'fs';
 import npmPackageArg from 'npm-package-arg';
 import packageJson from 'package-json';
 import * as path from 'path';
-import pify from 'pify';
 import spdxCorrect from 'spdx-correct';
 import spdxSatisfies from 'spdx-satisfies';
-import {inspect} from 'util';
+import {inspect, promisify} from 'util';
 
 import * as config from './config';
 import {GitHubRepository} from './github';
@@ -28,9 +27,9 @@ import {Dependencies, ensurePackageJson, PackageJson} from './package-json-file'
 
 export {GitHubRepository} from './github';
 
-const fsAccess = pify(fs.access);
-const fsReadDir = pify(fs.readdir);
-const fsReadFile = pify(fs.readFile);
+const fsAccess = promisify(fs.access);
+const fsReadDir = promisify(fs.readdir);
+const fsReadFile = promisify(fs.readFile);
 
 // Valid license IDs defined in https://spdx.org/licenses/ must be used whenever
 // possible. When adding new licenses, please consult the relevant documents.

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,12 +14,12 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import pify from 'pify';
 import stripJsonComments from 'strip-json-comments';
+import {promisify} from 'util';
 
 import {GitHubRepository} from './github';
 
-const fsReadFile = pify(fs.readFile);
+const fsReadFile = promisify(fs.readFile);
 
 const CONFIG_FILE_NAME = 'js-green-licenses.json';
 

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -21,10 +21,10 @@
 import * as fs from 'fs';
 import makeDir from 'make-dir';
 import * as path from 'path';
-import pify from 'pify';
 import * as tmp from 'tmp';
+import {promisify} from 'util';
 
-const writeFilep = pify(fs.writeFile);
+const writeFilep = promisify(fs.writeFile);
 
 export interface Fixtures {
   // If string, we create a file with that string contents. If fixture, we


### PR DESCRIPTION
Since this only works for nodejs 8 and up, we can drop pify and just use `util.promisify`.