### PR TITLE
feat: support private packages

### DIFF
--- a/src/checker.ts
+++ b/src/checker.ts
@@ -138,7 +138,12 @@ export class LicenseChecker extends EventEmitter {
     // https://docs.npmjs.com/files/package.json#license for details. The code
     // below is a little complicated to deal with those cases.
     const license = pkgJson.license || pkgJson.licenses;
-    if (!license) return null;
+    if (!license) {
+      if (pkgJson.private) {
+        return 'private';
+      }
+      return null;
+    }
     if (typeof license === 'string') return license;
     if (Array.isArray(license)) {
       const types = license.map(x => x.type).filter(x => !!x);

--- a/src/package-json-file.ts
+++ b/src/package-json-file.ts
@@ -25,6 +25,7 @@ export interface Dependencies {
 export interface PackageJson {
   name: string;
   version: string;
+  private?: boolean;
   license?: License;
   licenses?: License;
   dependencies?: Dependencies;
@@ -54,9 +55,10 @@ function isDependencies(obj: any): obj is Dependencies {
 
 function isPackageJson(obj: {}): obj is PackageJson {
   const json = obj as PackageJson;
-  return typeof json.name === 'string' && typeof json.version === 'string' &&
-      (json.license === undefined || isLicense(json.license)) &&
-      (json.licenses === undefined || isLicense(json.licenses)) &&
+  return (typeof json.private === 'boolean' && json.private) ||
+      (typeof json.name === 'string' && typeof json.version === 'string' &&
+       (json.license === undefined || isLicense(json.license)) &&
+       (json.licenses === undefined || isLicense(json.licenses))) &&
       (json.dependencies === undefined || isDependencies(json.dependencies)) &&
       (json.devDependencies === undefined ||
        isDependencies(json.devDependencies));

--- a/test/checker-test.ts
+++ b/test/checker-test.ts
@@ -271,3 +271,67 @@ test.serial('errors properly output to console', async t => {
   t.regex(consoleOutput, /EVIL: bar@4\.5\.6/);
   t.regex(consoleOutput, /1 non-green licenses found\./);
 });
+
+test.serial('accept private package (local repo)', t => {
+  const packageJson = JSON.stringify({
+    private: true,
+    dependencies: {
+
+    },
+  });
+  const configJson = JSON.stringify({
+    greenLicenses: [
+      'private',
+    ],
+  });
+  return withFixtures(
+      {
+        'path/to/dir': {
+          'package.json': packageJson,
+          'js-green-licenses.json': configJson,
+        },
+      },
+      async () => {
+        requestedPackages = [];
+        const nonGreenPackages: string[] = [];
+        const checker = new LicenseChecker();
+        checker.on('non-green-license', arg => {
+          nonGreenPackages.push(`${arg.packageName}@${arg.version}`);
+        });
+        await checker.checkLocalDirectory('path/to/dir');
+        t.deepEqual(requestedPackages, []);
+        t.deepEqual(nonGreenPackages, []);
+      });
+});
+
+test.serial('decline private package (local repo)', t => {
+  const packageJson = JSON.stringify({
+    private: true,
+    dependencies: {
+
+    },
+  });
+  const configJson = JSON.stringify({
+    greenLicenses: [
+      'ISC',
+    ],
+  });
+  return withFixtures(
+      {
+        'path/to/dir': {
+          'package.json': packageJson,
+          'js-green-licenses.json': configJson,
+        },
+      },
+      async () => {
+        requestedPackages = [];
+        const nonGreenPackages: string[] = [];
+        const checker = new LicenseChecker();
+        checker.on('non-green-license', arg => {
+          nonGreenPackages.push(`${arg.packageName}@${arg.version}`);
+        });
+        await checker.checkLocalDirectory('path/to/dir');
+        t.deepEqual(requestedPackages, []);
+        t.deepEqual(nonGreenPackages, ['undefined@undefined']);
+      });
+});


### PR DESCRIPTION
Adds support for private packages, without name and version. 

It's common for a monorepo project to have a private root package.json, like:
```
{
  "private": true,
  "devDependencies": {
  },
  "workspaces": [
    "packages/*"
  ]
}
```

It breaks license verification currently, because such package doesn't have name and version. 


My PR fixes that, by accepting such package.json file, and using `private` license if it's not specified