### PR TITLE
fix: Added support for the UNLICENSED NPM magic value (fixes #113)

### DIFF
--- a/src/checker.ts
+++ b/src/checker.ts
@@ -196,6 +196,12 @@ export class LicenseChecker extends EventEmitter {
   }
 
   private correctLicenseName(license: string): string | null {
+    // NPM specific value.
+    if (license === 'UNLICENSED' || license === 'UNLICENCED') {
+      console.warn(`Unlicensed package, specified license: ${license}`);
+      return 'UNLICENSED';
+    }
+
     const corrected = spdxCorrect(license);
     if (this.opts.verbose && corrected && corrected !== license) {
       console.warn(`Correcting ${license} to ${corrected}`);


### PR DESCRIPTION
As far as I'm aware only all caps spelling (with alternative UNLICENCED spelling) is allowed (see: [validate-npm-package-license.js](https://github.com/kemitchell/validate-npm-package-license.js/blob/master/index.js#L39)).

This resolves that issue, the library correctly treats UNLICENSED as non-green (all copyright retained). I've added a test case for that as well.