### PR TITLE
list licenses in verbose mode

### DIFF
--- a/src/checker.ts
+++ b/src/checker.ts
@@ -347,6 +347,9 @@ export class LicenseChecker extends EventEmitter {
       console.log(`${packageName} is allowlisted.`);
     } else {
       const license = this.getLicense(json);
+      if (this.opts.verbose) {
+        console.log(`${packageAndVersion},${license}`);
+      }
       if (!this.isGreenLicense(license)) {
         this.emit('non-green-license', {
           packageName,


### PR DESCRIPTION
Shows a list of licenses in verbose mode. ( https://github.com/google/js-green-licenses/issues/151 )

Hopefully someday `reports` command will be added like in this case:
https://github.com/google/go-licenses#reports

I tested it and it works fine.
```
jmnote@cloudshell:~/ws/js-green-licenses$ npx ts-node src/cli.ts --verbose --local ../venti/web/
Correcting LGPL-2.0 to LGPL-2.0-only
Correcting LGPL-2.1 to LGPL-2.1-only
Correcting LGPL-3.0 to LGPL-3.0-or-later
Checking ../venti/web/package.json...

venti@0.0.0,Apache-2.0
@mdi/font@6.9.96,Apache-2.0
vue@3.2.47,MIT
@vue/shared@3.2.47,MIT
@vue/compiler-dom@3.2.47,MIT
@vue/compiler-core@3.2.47,MIT
@babel/parser@7.21.2,MIT
estree-walker@2.0.2,MIT
source-map@0.6.1,BSD-3-Clause
@vue/runtime-dom@3.2.47,MIT
@vue/runtime-core@3.2.47,MIT
@vue/reactivity@3.2.47,MIT
csstype@2.6.21,MIT
@vue/compiler-sfc@3.2.47,MIT
@vue/compiler-ssr@3.2.47,MIT
@vue/reactivity-transform@3.2.47,MIT
magic-string@0.25.9,MIT
sourcemap-codec@1.4.8,MIT
postcss@8.4.21,MIT
nanoid@3.3.4,MIT
picocolors@1.0.0,ISC
source-map-js@1.0.2,BSD-3-Clause
@vue/server-renderer@3.2.47,MIT
vue-router@4.1.6,MIT
@vue/devtools-api@6.5.0,MIT
All green!
```